### PR TITLE
(WIP) Provide information to users if a C# suggestion cannot be applied because a lower language version

### DIFF
--- a/src/Sharpen.Engine/Analysis/BaseScopeAnalyzer.cs
+++ b/src/Sharpen.Engine/Analysis/BaseScopeAnalyzer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Sharpen.Engine.Extensions.CodeDetection;
 using Sharpen.Engine.SharpenSuggestions.CSharp80.NullableReferenceTypes.Suggestions;
 
@@ -11,6 +12,7 @@ namespace Sharpen.Engine.Analysis
 {
     public abstract class BaseScopeAnalyzer : IScopeAnalyzer
     {
+        
         // We want to avoid creation of a huge number of temporary Action objects
         // while invoking Parallel.Invoke().
         // That's why we create these Action objects in advance and at the beginning
@@ -22,6 +24,15 @@ namespace Sharpen.Engine.Analysis
                 {
                     foreach (var analysisResult in analyzer.Analyze(syntaxTree, semanticModel, analysisContext))
                     {
+                        if ((analyzer as ISharpenSuggestion) != null)
+                        {
+                            var suggestionLanguageVersion = Convert.ToInt64(Convert.ToDouble(((ISharpenSuggestion)analyzer).MinimumLanguageVersion));
+                            if (suggestionLanguageVersion > (int)analysisContext.LanguageVersion)
+                            {
+                                analysisResult.IsApplicableOnCurrentLanguageVersion = false;
+                            }
+
+                        }
                         results.Add(analysisResult);
                         // TODO-IG: Remove this workaround once the whole analysis stuff is refactored.
                         if (analysisResult.Suggestion is BaseEnableNullableContextAndDeclareIdentifierAsNullableSuggestion)

--- a/src/Sharpen.Engine/Analysis/SingleSyntaxTreeAnalysisContext.cs
+++ b/src/Sharpen.Engine/Analysis/SingleSyntaxTreeAnalysisContext.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
 
 namespace Sharpen.Engine.Analysis
 {
@@ -19,6 +21,9 @@ namespace Sharpen.Engine.Analysis
         /// </summary>
         public string LogicalFolderPath { get; }
 
+        public LanguageVersion LanguageVersion { get; }
+
+       
         // To be used in unit tests only.
         internal SingleSyntaxTreeAnalysisContext(string projectName, string logicalFolderPath)
         {
@@ -28,7 +33,9 @@ namespace Sharpen.Engine.Analysis
 
         public SingleSyntaxTreeAnalysisContext(Document document)
         {
+
             ProjectName = document.Project.Name;
+            LanguageVersion =  ((CSharpParseOptions)document.Project.ParseOptions).LanguageVersion;
             // TODO-PERF: Create a logical folder path string only once.
             //            There are usually several or even many documents that share the same logical folder.
             //            Right now, a new string with the same content will be create for each of such documents.

--- a/src/Sharpen.Engine/AnalysisResult.cs
+++ b/src/Sharpen.Engine/AnalysisResult.cs
@@ -12,6 +12,7 @@ namespace Sharpen.Engine
 
         public ISharpenSuggestion Suggestion { get; }
 
+        public bool IsApplicableOnCurrentLanguageVersion { get; set; } = true;
         // This will change for sure as soon as we introduce analysis that goes beyond a single syntax tree.
         // But so far so good :-)
         public SingleSyntaxTreeAnalysisContext AnalysisContext { get; } 


### PR DESCRIPTION
Hi @ironcev , 

I was able to compare the minimum language version with the project's language version, 
however had a couple of questions: 

1. We are using `CSharpLanguageVersions` class to identify language versions, which can also be done via `Microsoft.CodeAnalysis.CSharp.LanguageVersion` enum, do I replace the class with the enum around the source code ? 

2. Attaching the expected screenshot on the [issue ](https://github.com/sharpenrocks/Sharpen/issues/13)itself.

Please let me know so I can update the issue.
